### PR TITLE
Fix Android 14 camera storage and lower min SDK to 26

### DIFF
--- a/nativephp.json
+++ b/nativephp.json
@@ -23,12 +23,12 @@
     ],
 
     "android": {
-        "min_version": 33,
+        "min_version": 26,
         "permissions": [
             "android.permission.CAMERA",
             "android.permission.RECORD_AUDIO",
             "android.permission.FOREGROUND_SERVICE",
-            "android.permission.FOREGROUND_SERVICE_SHORT_SERVICE"
+            "android.permission.FOREGROUND_SERVICE_CAMERA"
         ],
         "dependencies": {
             "implementation": []
@@ -36,7 +36,7 @@
         "services": [
             {
                 "name": ".CameraForegroundService",
-                "foregroundServiceType": "shortService",
+                "foregroundServiceType": "camera",
                 "exported": false
             }
         ]


### PR DESCRIPTION
- Lower android.min_version from 33 to 26
- Replace shortService foreground service type with camera, as Android 14 removed support for shortService in camera-related foreground services
- Replace FOREGROUND_SERVICE_SHORT_SERVICE permission with FOREGROUND_SERVICE_CAMERA to match the updated service type

https://claude.ai/code/session_01CgNaWBHBTNB96ppmixgSZD