### PR TITLE
Lower Android min SDK requirement from 33 to 26

### DIFF
--- a/nativephp.json
+++ b/nativephp.json
@@ -23,7 +23,7 @@
     ],
 
     "android": {
-        "min_version": 33,
+        "min_version": 26,
         "permissions": [
             "android.permission.CAMERA",
             "android.permission.RECORD_AUDIO",


### PR DESCRIPTION
## Summary

- Lowers `android.min_version` in `nativephp.json` from `33` to `26`
- The Kotlin foreground service code is already fully guarded with `Build.VERSION.SDK_INT` checks — `shortService` type and `FOREGROUND_SERVICE_TYPE_SHORT_SERVICE` are only used on API 34+, and `startForegroundService`/notification channels are only used on API 26+
- The `foregroundServiceType: "shortService"` manifest attribute is silently ignored on older API levels
- API 26 is the true minimum required, which matches NativePHP Mobile's own default `NATIVEPHP_ANDROID_MIN_SDK`

Fixes nativephp/mobile-air#63 — users with the default min SDK of 26 were blocked from building when this plugin was installed.