### PR TITLE
fix(ios): convert gallery HEIC/HEIF to JPEG for WebView compatibility

### DIFF
--- a/resources/ios/CameraFunctions.swift
+++ b/resources/ios/CameraFunctions.swift
@@ -661,10 +661,35 @@ extension CameraGalleryManager: PHPickerViewControllerDelegate {
 
             try fileManager.copyItem(at: url, to: destinationURL)
 
+            var finalURL = destinationURL
+            var finalExtension = fileExtension
+
+            if type == "image" {
+                let lowerExt = fileExtension.lowercased()
+
+                // HEIC/HEIF cannot be shown in WKWebView; normalize to JPEG like camera capture.
+                if lowerExt == "heic" || lowerExt == "heif" {
+                    if let image = UIImage(contentsOfFile: destinationURL.path),
+                       let jpegData = image.jpegData(compressionQuality: 0.9) {
+                        let jpegName = "gallery_selected_\(timestamp)_\(index).jpg"
+                        let jpegURL = galleryDir.appendingPathComponent(jpegName)
+
+                        if fileManager.fileExists(atPath: jpegURL.path) {
+                            try? fileManager.removeItem(at: jpegURL)
+                        }
+
+                        try jpegData.write(to: jpegURL)
+                        try? fileManager.removeItem(at: destinationURL)
+                        finalURL = jpegURL
+                        finalExtension = "jpg"
+                    }
+                }
+            }
+
             let fileInfo: [String: Any] = [
-                "path": destinationURL.path,
-                "mimeType": getMimeType(for: fileExtension),
-                "extension": fileExtension,
+                "path": finalURL.path,
+                "mimeType": getMimeType(for: finalExtension),
+                "extension": finalExtension,
                 "type": type
             ]
 
@@ -685,6 +710,10 @@ extension CameraGalleryManager: PHPickerViewControllerDelegate {
             return "image/gif"
         case "webp":
             return "image/webp"
+        case "heic":
+            return "image/heic"
+        case "heif":
+            return "image/heif"
         case "mp4":
             return "video/mp4"
         case "mov":


### PR DESCRIPTION
## Problem

On iOS, **camera capture** saves photos as **JPEG**, and the README states **“JPEG for photos”**.

The **gallery picker** copies files **as-is** via `loadFileRepresentation`. On iPhone that is often **HEIC/HEIF**. Those files are valid on disk, but **WKWebView cannot display HEIC in `<img>`**, so profile/media previews in Livewire, Blade, or Inertia fail even when upload still works.

Camera and gallery therefore behave differently within the same plugin.

## Solution

In `copyFileToCache`, **after** copying to cache:

- If the image extension is **`heic` or `heif`**, convert to **JPEG** with `jpegData(compressionQuality: 0.9)` (same as camera capture).
- Return `.jpg` path and `image/jpeg` mime type.
- **JPEG, PNG, GIF, WebP, and video** are unchanged — same flow as today.

~35 lines in `resources/ios/CameraFunctions.swift` only. No change to `processPickerResults` or event payload shape.

## Why this is needed

- Aligns gallery behavior with **documented** photo format and **existing** camera JPEG handling.
- Fixes a **common** NativePHP Mobile use case: showing a gallery image in the WebView before upload.
- **Minimal and safe** — only HEIC/HEIF are converted; other formats are not altered.