### PR TITLE
Fix: Use PHP-accessible, persistent storage for captured media (Android + iOS)

### DIFF
--- a/resources/android/CameraCoordinator.kt
+++ b/resources/android/CameraCoordinator.kt
@@ -161,7 +161,10 @@ class CameraCoordinator : Fragment() {
             val cancelEventClass = "Native\\Mobile\\Events\\Camera\\PhotoCancelled"
 
             if (success && pendingCameraUri != null) {
-                val dst = File(context.cacheDir, "captured_${System.currentTimeMillis()}.jpg")
+                // Use app's files directory (accessible to PHP) instead of cache
+                val photoDir = File(context.filesDir, "Camera")
+                photoDir.mkdirs()
+                val dst = File(photoDir, "captured_${System.currentTimeMillis()}.jpg")
 
                 try {
                     context.contentResolver.openInputStream(pendingCameraUri!!)?.use { input ->
@@ -309,8 +312,8 @@ class CameraCoordinator : Fragment() {
                         val context = requireContext()
                         val timestamp = System.currentTimeMillis()
 
-                        // Use Gallery subfolder in cache directory
-                        val galleryDir = File(context.cacheDir, "Gallery")
+                        // Use Gallery subfolder in app's files directory (accessible to PHP)
+                        val galleryDir = File(context.filesDir, "Gallery")
                         galleryDir.mkdirs()
 
                         val dst = File(galleryDir, "gallery_selected_$timestamp")
@@ -407,8 +410,8 @@ class CameraCoordinator : Fragment() {
 
                         Log.d(TAG, "🧵 Background processing ${uris.size} files")
 
-                        // Use Gallery subfolder in cache directory
-                        val galleryDir = File(context.cacheDir, "Gallery")
+                        // Use Gallery subfolder in app's files directory (accessible to PHP)
+                        val galleryDir = File(context.filesDir, "Gallery")
                         galleryDir.mkdirs()
 
                         uris.forEachIndexed { index, uri ->
@@ -657,7 +660,10 @@ class CameraCoordinator : Fragment() {
 
         try {
             val timestamp = System.currentTimeMillis()
-            val cacheFile = File(context.cacheDir, "video_$timestamp.mp4")
+            // Use app's files directory (accessible to PHP) instead of cache
+            val videoDir = File(context.filesDir, "Camera")
+            videoDir.mkdirs()
+            val cacheFile = File(videoDir, "video_$timestamp.mp4")
 
             context.contentResolver.openInputStream(uri)?.use { input ->
                 cacheFile.outputStream().buffered(64 * 1024).use { output ->

--- a/resources/ios/CameraFunctions.swift
+++ b/resources/ios/CameraFunctions.swift
@@ -299,14 +299,20 @@ final class CameraVideoDelegate: NSObject, UIImagePickerControllerDelegate, UINa
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let fm = FileManager.default
 
-            // Use temporary directory
-            let tempDir = fm.temporaryDirectory
+            // Use Application Support directory instead of the temporary directory.
+            // NSTemporaryDirectory() can be purged by iOS at any time (low disk space,
+            // app relaunch, etc), which risks the same "file went missing before PHP
+            // could read it" failure mode as Android's cache dir (see Issue #8).
+            // Application Support is private, persistent, and not auto-purged.
+            let supportDir = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            let cameraDir = supportDir.appendingPathComponent("Camera", isDirectory: true)
+            try? fm.createDirectory(at: cameraDir, withIntermediateDirectories: true)
 
             // Generate unique filename
             let timestamp = Int(Date().timeIntervalSince1970 * 1000)
             let fileExtension = videoURL.pathExtension.isEmpty ? "mp4" : videoURL.pathExtension
             let filename = "captured_video_\(timestamp).\(fileExtension)"
-            var fileURL = tempDir.appendingPathComponent(filename)
+            var fileURL = cameraDir.appendingPathComponent(filename)
 
             do {
                 // Remove existing file if present
@@ -416,13 +422,19 @@ final class CameraPhotoDelegate: NSObject, UIImagePickerControllerDelegate, UINa
         DispatchQueue.global(qos: .utility).async { [weak self] in
             let fm = FileManager.default
 
-            // Use temporary directory
-            let tempDir = fm.temporaryDirectory
+            // Use Application Support directory instead of the temporary directory.
+            // NSTemporaryDirectory() can be purged by iOS at any time (low disk space,
+            // app relaunch, etc), which risks the same "file went missing before PHP
+            // could read it" failure mode as Android's cache dir (see Issue #8).
+            // Application Support is private, persistent, and not auto-purged.
+            let supportDir = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+            let cameraDir = supportDir.appendingPathComponent("Camera", isDirectory: true)
+            try? fm.createDirectory(at: cameraDir, withIntermediateDirectories: true)
 
             // Generate unique filename
             let timestamp = Int(Date().timeIntervalSince1970 * 1000)
             let filename = "captured_photo_\(timestamp).jpg"
-            var fileURL = tempDir.appendingPathComponent(filename)
+            var fileURL = cameraDir.appendingPathComponent(filename)
 
             do {
                 // Remove existing file if present
@@ -642,9 +654,13 @@ extension CameraGalleryManager: PHPickerViewControllerDelegate {
     private func copyFileToCache(url: URL, index: Int, type: String, completion: @escaping ([String: Any]?) -> Void) {
         let fileManager = FileManager.default
 
-        // Use temporary directory with Gallery subfolder
-        let tempDir = fileManager.temporaryDirectory
-        let galleryDir = tempDir.appendingPathComponent("Gallery", isDirectory: true)
+        // Use Application Support directory with a Gallery subfolder instead of the
+        // temporary directory. NSTemporaryDirectory() can be purged by iOS at any
+        // time, which risks the same "file went missing before PHP could read it"
+        // failure mode as Android's cache dir (see Issue #8). Application Support
+        // is private, persistent, and not auto-purged.
+        let supportDir = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let galleryDir = supportDir.appendingPathComponent("Gallery", isDirectory: true)
 
         // Ensure Gallery directory exists
         try? fileManager.createDirectory(at: galleryDir, withIntermediateDirectories: true)


### PR DESCRIPTION
Fixes #8

## Problem
On Android, `PhotoTaken` returned a path inside `context.cacheDir` (`/data/user/0/<pkg>/cache/...`) that PHP could not read via `file_exists()`/`file_get_contents()`.

## Fix
- **Android**: photo, video, and gallery captures now save to `context.filesDir/Camera` and `context.filesDir/Gallery` instead of `cacheDir`.
- **iOS**: same class of risk existed via `NSTemporaryDirectory()`, which iOS can purge at any time. Captures now save to `Application Support/Camera` and `/Gallery` instead, matching Android's persistent-storage approach. `isExcludedFromBackup` is preserved so backups aren't bloated.

## Testing
Verified on a Laravel/NativePHP app (Android emulator + physical device): captured photo path now resolves under `files/Camera/...`, and `file_exists()`, `file_get_contents()`, and `Storage::put()` all succeed against the returned path.